### PR TITLE
Revert "Wrap README prose at 80 columns"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,30 +3,21 @@ Initialize Playwright tests with just one command.
 
 ## Usage
 
-This repository is used to initialize a Playwright test directory for a new
-neeto app. Executing the actions in this repository will let you create a
-Playwright test with setup, teardown and all necessary configurations needed for
-the neeto ecosystem by simply answering a few questions.
+This repository is used to initialize a Playwright test directory for a new neeto app. Executing the actions in this repository will let you
+create a Playwright test with setup, teardown and all necessary configurations needed for the neeto ecosystem by simply answering a few questions.
 
 ### Pre-requisites
 
-1. Create a new project in
-   [neetoPlaydash](https://neeto-engineering.neetoplaydash.com) for the neeto
-   product in which you want to run the tests in.
-2. Create a new project in [Currents.dev](https://app.currents.dev) for the
-   neeto product in which you want to run the tests in.
+1. Create a new project in [neetoPlaydash](https://neeto-engineering.neetoplaydash.com) for the neeto product in which you want to run the tests in.
+2. Create a new project in [Currents.dev](https://app.currents.dev) for the neeto product in which you want to run the tests in.
 
 ### Steps
 
-1. Clone the repository and install all the dependencies by executing the
-   command: `yarn install`.
+1. Clone the repository and install all the dependencies by executing the command: `yarn install`.
 2. Create the Playwright application by executing the command: `yarn generate`.
-3. You will be asked a series of questions for which you have to provide the
-   proper answers.
-4. Once done a new directory called `playwright-tests-starter` will be
-   generated.
-5. Copy this directory within the neeto app for which you want to write the
-   tests for and rename it to `playwright-tests`.
+3. You will be asked a series of questions for which you have to provide the proper answers.
+4. Once done a new directory called `playwright-tests-starter` will be generated.
+5. Copy this directory within the neeto app for which you want to write the tests for and rename it to `playwright-tests`.
 6. Navigate inside the directory and initialize it by executing `yarn install`.
 7. Execute `yarn playwright:headed` and the tests should run properly.
 
@@ -34,9 +25,8 @@ the neeto ecosystem by simply answering a few questions.
 
 ### Adding CI configuration
 
-You need to add the neeto-ci configurations for executing the Playwright tests
-in the review environment and staging environment and you have to configure the
-nightly runs. For this create three new files in the .neetoci directory:
+You need to add the neeto-ci configurations for executing the Playwright tests in the review environment and staging environment and you have to configure
+the nightly runs. For this create three new files in the .neetoci directory:
 
 ```bash
 # Execute at the root of the neeto app
@@ -46,9 +36,8 @@ touch .neetoci/playwright-staging.yml
 touch .neetoci/playwright.yml
 ```
 
-Now add the contents of the newly created configurations as given below. Replace
-all occurrences of `<neetoapp>` with the proper app name. Eg: `neetoform`,
-`neetocal`
+Now add the contents of the newly created configurations as given below. Replace all occurrences of `<neetoapp>` with the proper app name.
+Eg: `neetoform`, `neetocal`
 
 ```yml
 # .neetoci/playwright-nightly-staging.yml
@@ -188,13 +177,10 @@ triggers:
 
 ### Moving the generated .gitignore entries
 
-When generating the starter Playwright code, we generate some required
-.gitignore files along with it. Since the application already has a .gitignore
-file, its redundant to keep two files. So we can move all the .gitignore entries
-in the `playwright-tests` directory to the one in the root of the application.
-To do this you can copy the entries in the the `playwright-tests/.gitignore`
-file to the `.gitignore` file and prefix all the of them with
-`/playwright-tests/`
+When generating the starter Playwright code, we generate some required .gitignore files along with it. Since the application already has a
+.gitignore file, its redundant to keep two files. So we can move all the .gitignore entries in the `playwright-tests` directory to the one
+in the root of the application. To do this you can copy the entries in the the `playwright-tests/.gitignore` file to the `.gitignore` file
+and prefix all the of them with `/playwright-tests/`
 
 ```
 # playwright-tests/.gitignore


### PR DESCRIPTION
**Description**

- Removed: reverts the 80-column README prose wrapping.

Restores `README.md` to its content from before the wrap commit, taken from git
history (the parent of that commit) rather than from a working copy.

Reverting so the wrapping can be redone at 120 columns from the original text.
Re-wrapping the already-wrapped file is not equivalent — wrapping at 80 can
split a line so short that re-wrapping at 120 cannot rejoin it, which affects 5
of 266 READMEs. Going back to the original avoids that.

Only `README.md` is touched.

**Checklist**

- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added the necessary label (patch/minor/major - If package publish is required).
- [x] I have followed the suggested description format and styling.

**Reviewers**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
